### PR TITLE
Added feature to add additional arguments to psalm command

### DIFF
--- a/src/PsalmCheckAction.php
+++ b/src/PsalmCheckAction.php
@@ -29,23 +29,19 @@ final class PsalmCheckAction implements Action
 
     public function execute(Config $config, IO $io, Repository $repository, Config\Action $action): void
     {
-        $repositoryRootDir = $repository->getRoot();
-        $psalmConfig = $this->psalmConfigLoader->getConfigForProject($repositoryRootDir);
-
-        $indexOperator = $repository->getIndexOperator();
-
-        if ($indexOperator->hasStagedFilesOfType("php") === false) {
-            return;
-        }
-        $stagedPhpFiles = $indexOperator->getStagedFilesOfType("php");
-        $checkedPhpFiles = array_filter($stagedPhpFiles, function (string $phpFile) use ($psalmConfig): bool {
-            return $psalmConfig->belongsToProjectFiles($phpFile);
-        });
-        if (count($checkedPhpFiles) === 0) {
+        $checkedPhpFiles = $this->getStagedPhpFiles($repository);
+        if ($checkedPhpFiles === []) {
             return;
         }
 
         $psalmArgs = [];
+
+        $additionalPsalmArgs = $this->getAdditionalArguments($action);
+        foreach ($additionalPsalmArgs as $additionalPsalmArg) {
+            $psalmArgs[] = $additionalPsalmArg;
+        }
+
+
         foreach ($checkedPhpFiles as $checkedPhpFile) {
             $psalmArgs[] = escapeshellarg($checkedPhpFile);
         }
@@ -64,5 +60,40 @@ final class PsalmCheckAction implements Action
                 throw new \LogicException("Psalm returned with an unexpected code " . $psalmResult->getCode());
             }
         }
+    }
+
+    private function getStagedPhpFiles(Repository $repository): array
+    {
+        $repositoryRootDir = $repository->getRoot();
+        $psalmConfig = $this->psalmConfigLoader->getConfigForProject($repositoryRootDir);
+
+        $indexOperator = $repository->getIndexOperator();
+
+        if ($indexOperator->hasStagedFilesOfType("php") === false) {
+            return [];
+        }
+
+        $stagedPhpFiles = $indexOperator->getStagedFilesOfType("php");
+        return array_filter($stagedPhpFiles, function (string $phpFile) use ($psalmConfig): bool {
+            return $psalmConfig->belongsToProjectFiles($phpFile);
+        });
+    }
+
+    private function getAdditionalArguments(Config\Action $action): array
+    {
+        $options = $action->getOptions();
+        $extraArgs = $options->get('args', []);
+
+        $additionalPsalmArgs = [];
+
+        if (is_array($extraArgs)) {
+            foreach ($extraArgs as $arg) {
+                $additionalPsalmArgs[] = $arg;
+            }
+        } elseif (is_string($extraArgs)) {
+            $additionalPsalmArgs[] = $extraArgs;
+        }
+
+        return $additionalPsalmArgs;
     }
 }

--- a/tests/PsalmCheckActionTest.php
+++ b/tests/PsalmCheckActionTest.php
@@ -208,4 +208,62 @@ final class PsalmCheckActionTest extends TestCase
 
         $this->psalmCheckAction->execute($this->config, $io, $this->repository, $configAction);
     }
+
+	public function testIncludesAdditionalArgumentsFromOptionsArray(): void
+	{
+		$this->indexOperator->expects($this->once())
+			->method("hasStagedFilesOfType")
+			->with("php")
+			->willReturn(true);
+		$this->indexOperator->expects($this->once())
+			->method("getStagedFilesOfType")
+			->with("php")
+			->willReturn(["foo.php"]);
+		$this->psalmConfig->expects($this->any())
+			->method("belongsToProjectFiles")
+			->willReturn(true);
+
+		$configAction = new Config\Action(PsalmCheckAction::class, [
+			'args' => ['--no-cache', '--stats']
+		]);
+
+		$psalmBin = str_replace("/", DIRECTORY_SEPARATOR, "./vendor/bin/psalm");
+		$expectedCmd = $psalmBin . " --no-cache --stats 'foo.php'";
+
+		$this->processor->expects($this->once())
+			->method("run")
+			->with($this->equalTo($expectedCmd))
+			->willReturn(new Result($expectedCmd, 0));
+
+		$this->psalmCheckAction->execute($this->config, $this->io, $this->repository, $configAction);
+	}
+
+	public function testIncludesAdditionalArgumentsFromOptionsString(): void
+	{
+		$this->indexOperator->expects($this->once())
+			->method("hasStagedFilesOfType")
+			->with("php")
+			->willReturn(true);
+		$this->indexOperator->expects($this->once())
+			->method("getStagedFilesOfType")
+			->with("php")
+			->willReturn(["foo.php"]);
+		$this->psalmConfig->expects($this->any())
+			->method("belongsToProjectFiles")
+			->willReturn(true);
+
+		$configAction = new Config\Action(PsalmCheckAction::class, [
+			'args' => '--diff'
+		]);
+
+		$psalmBin = str_replace("/", DIRECTORY_SEPARATOR, "./vendor/bin/psalm");
+		$expectedCmd = $psalmBin . " --diff 'foo.php'";
+
+		$this->processor->expects($this->once())
+			->method("run")
+			->with($this->equalTo($expectedCmd))
+			->willReturn(new Result($expectedCmd, 0));
+
+		$this->psalmCheckAction->execute($this->config, $this->io, $this->repository, $configAction);
+	}
 }


### PR DESCRIPTION
With this PR you can add additional psalm arguments to the psalm command being run. You can configure this in the `captainhook.json` like this:

```
{
    "action": "\\Moxio\\CaptainHook\\Psalm\\PsalmCheckAction",
    "options": {
        "args": ["--no-cache"]
    }
}
```

